### PR TITLE
Fix: free fGIF in destructor

### DIFF
--- a/Classes/Gif/GifMovieData.cpp
+++ b/Classes/Gif/GifMovieData.cpp
@@ -99,7 +99,8 @@ cocos2d::Texture2D* GIFMovieData::StaticGetTexture( const char* file, int index 
 
 GIFMovieData::~GIFMovieData()
 {
-
+	DGifCloseFile(fGIF);
+	fGIF = NULL;
 }
  
 static uint32_t savedimage_duration(const SavedImage* image)


### PR DESCRIPTION
~GIFMovieData() 调用 DGifCloseFile(fGIF); 释放内存
DGifOpen 用 malloc 给 fGIF 分配内存,正常情况下 fGIF 没有 free